### PR TITLE
Readded is-fullheight-with-navbar

### DIFF
--- a/bin/spec
+++ b/bin/spec
@@ -16,6 +16,7 @@ cli
   .description('generate a spec documentation')
   .action((specFile, cmd) => {
     const { template } = cmd
+    console.log("test")
     generateDoc(specFile, { template })
   })
 

--- a/examples/bulma-0.7.4.spec
+++ b/examples/bulma-0.7.4.spec
@@ -413,6 +413,7 @@ text weight:
   - is-medium
   - is-large
   - is-fullheight
+  - is-fullheight-with-navbar
 
   ## Section
 


### PR DESCRIPTION
Feature was not removed in 0.7.3, it should still be present in bulma-0.7.4.spec