### PR TITLE
Port parser to enolib, adapt examples to eno's final specification

### DIFF
--- a/examples/bulma-0.7.1.spec
+++ b/examples/bulma-0.7.1.spec
@@ -228,14 +228,14 @@ text weight:
   default: .columns>(.column>.notification.is-primary{First column})+(.column>.notification.is-primary{Second column})+(.column>.notification.is-primary{Third column})+(.column>.notification.is-primary{Fourth column})
 
   gap:
-  | If you want to remove the space between the columns, add the is-gapless modifier on the columns container.
+  \ If you want to remove the space between the columns, add the is-gapless modifier on the columns container.
 
   multi:
-  | You can combine it with the is-multiline modifier.
+  \ You can combine it with the is-multiline modifier.
 
   alignment:
-  | While you can use empty columns (like <div class="column"></div>) to create horizontal space around .column elements,
-  | you can also use .is-centered on the parent .columns element.
+  \ While you can use empty columns (like <div class="column"></div>) to create horizontal space around .column elements,
+  \ you can also use .is-centered on the parent .columns element.
 
   ### modifiers
 
@@ -316,10 +316,10 @@ text weight:
   default: .container>.notification{Container content.}
 
   fluid:
-  | If you don't want to have a maximum width but want to keep the 32px margin on the left and right sides, add the is-fluid modifier.
+  \ If you don't want to have a maximum width but want to keep the 32px margin on the left and right sides, add the is-fluid modifier.
 
   responsive:
-  | With the two modifiers .is-widescreen and .is-fullhd, you can have a fullwidth container until those specific breakpoints.
+  \ With the two modifiers .is-widescreen and .is-fullhd, you can have a fullwidth container until those specific breakpoints.
 
   ### modifiers
 
@@ -345,8 +345,8 @@ text weight:
   default: nav.level>.level-left>.level-item>p.subtitle.is-5>strong{123}^posts^^.level-item>.field.has-addons>p.control>input.input[placeholder={Find a post}]^p.control>button.button{Search}
 
   responsive:
-  | By default, for space concerns, the level is vertical on mobile. If you want the level to be horizontal on mobile as well,
-  | add the is-mobile modifier on the level container.
+  \ By default, for space concerns, the level is vertical on mobile. If you want the level to be horizontal on mobile as well,
+  \ add the is-mobile modifier on the level container.
 
   ### modifiers
 
@@ -376,13 +376,13 @@ text weight:
   default: section.hero.is-primary>.hero-body>.container>h1.title{Hero title}+h2.subtitle{Hero subtitle}
 
   colors:
-  | As with buttons, you can choose one of the 7 different colors.
+  \ As with buttons, you can choose one of the 7 different colors.
 
   gradients:
-  | By adding the is-bold modifier, you can generate a subtle gradient.
+  \ By adding the is-bold modifier, you can generate a subtle gradient.
 
   sizes:
-  | You can have even more imposing banners by using one of 3 different sizes.
+  \ You can have even more imposing banners by using one of 3 different sizes.
 
   ### modifiers
 
@@ -479,22 +479,22 @@ text weight:
   default: a.button{Button}
 
   colors:
-  | Colored buttons.
+  \ Colored buttons.
 
   sizes:
-  | Size matters.
+  \ Size matters.
 
   outlined:
-  | Outlined.
+  \ Outlined.
 
   inverted:
-  | Inverted.
+  \ Inverted.
 
   rounded:
-  | Rounded.
+  \ Rounded.
 
   loading:
-  | Loading
+  \ Loading
 
   ### modifiers
 
@@ -542,7 +542,7 @@ text weight:
   default: .content>ol>li{Coffee}+li{Tea}+li{Milk}
 
   sizes:
-  | You can use the is-small, is-medium and is-large modifiers to change the font size.
+  \ You can use the is-small, is-medium and is-large modifiers to change the font size.
 
   ### modifiers
 
@@ -564,7 +564,7 @@ text weight:
   default: a.delete
 
   sizes:
-  | It comes in 4 sizes.
+  \ It comes in 4 sizes.
 
   ### modifiers
 
@@ -579,10 +579,10 @@ text weight:
   default: span.icon>i.fas.fa-home
 
   colors:
-  | Since icon fonts are simply text, you can use the text color modifiers to change the icon's color.
+  \ Since icon fonts are simply text, you can use the text color modifiers to change the icon's color.
 
   sizes:
-  | Size matters.
+  \ Size matters.
 
   ### modifiers
 
@@ -599,10 +599,10 @@ text weight:
   default: figure.image>img[src=https://bulma.io/images/placeholders/128x128.png]
 
   ratio:
-  | There are 7 dimensions to choose from, useful for avatars.
+  \ There are 7 dimensions to choose from, useful for avatars.
 
   rounded:
-  | You can also make rounded images, using .is-rounded class.
+  \ You can also make rounded images, using .is-rounded class.
 
   ### modifiers
 
@@ -638,7 +638,7 @@ text weight:
   default: .notification>button.delete+{Lorem ipsum dolor sit amet.}
 
   colors:
-  | Colored notifications.
+  \ Colored notifications.
 
   ### modifiers
 
@@ -655,10 +655,10 @@ text weight:
   default: progress.progress
 
   colors:
-  | Colored progress bars.
+  \ Colored progress bars.
 
   sizes:
-  | Size matters.
+  \ Size matters.
 
   ### modifiers
 
@@ -676,19 +676,19 @@ text weight:
   default: table.table>thead>tr>th{Pos}+th{Pts}^^tfoot>tr>th{Pos}+th{Pts}^^tbody>tr>th{1}+td{Leicester City}+td{81}
 
   bordered:
-  | Add borders to all the cells.
+  \ Add borders to all the cells.
 
   striped:
-  | Add stripes to the table.
+  \ Add stripes to the table.
 
   narrow:
-  | Make the cells narrower.
+  \ Make the cells narrower.
 
   hoverable:
-  | You can add a hover effect on each row.
+  \ You can add a hover effect on each row.
 
   fullwidth:
-  | You can have a fullwidth table.
+  \ You can have a fullwidth table.
 
   ### modifiers
 
@@ -720,16 +720,16 @@ text weight:
   default: span.tag{Tag label}
 
   colors:
-  | Like with buttons, there are 10 different colors available.
+  \ Like with buttons, there are 10 different colors available.
 
   sizes:
-  | And 2 additional sizes.
+  \ And 2 additional sizes.
 
   rounded:
-  | You can add the is-rounded modifier to make a rounded tag.
+  \ You can add the is-rounded modifier to make a rounded tag.
 
   delete:
-  | You can add the is-delete modifier to turn the tag into a delete button.
+  \ You can add the is-delete modifier to turn the tag into a delete button.
 
   ### modifiers
 
@@ -779,7 +779,7 @@ text weight:
   default: h1.title{Title}
 
   spaced:
-  | You can maintain the normal spacing between titles and subtitles if you use the is-spaced modifier on the first element.
+  \ You can maintain the normal spacing between titles and subtitles if you use the is-spaced modifier on the first element.
 
   ### modifiers
 
@@ -810,13 +810,13 @@ text weight:
   default: .tabs>ul>li.is-active>a{Pictures}^li>a{Music}^li>a{Documents}
 
   alignment:
-  | To align the tabs list, use the is-centered or is-right modifier on the .tabs container.
+  \ To align the tabs list, use the is-centered or is-right modifier on the .tabs container.
 
   sizes:
-  | You can choose between 3 additional sizes ; is-small is-medium and is-large.
+  \ You can choose between 3 additional sizes ; is-small is-medium and is-large.
 
   styles:
-  | Stylised tabs.
+  \ Stylised tabs.
 
   ### modifiers
 

--- a/examples/bulma-0.7.4.spec
+++ b/examples/bulma-0.7.4.spec
@@ -233,14 +233,14 @@ text weight:
   default: .columns>(.column>.notification.is-primary{First column})+(.column>.notification.is-primary{Second column})+(.column>.notification.is-primary{Third column})+(.column>.notification.is-primary{Fourth column})
 
   gap:
-  | If you want to remove the space between the columns, add the is-gapless modifier on the columns container.
+  \ If you want to remove the space between the columns, add the is-gapless modifier on the columns container.
 
   multi:
-  | You can combine it with the is-multiline modifier.
+  \ You can combine it with the is-multiline modifier.
 
   alignment:
-  | While you can use empty columns (like <div class="column"></div>) to create horizontal space around .column elements,
-  | you can also use .is-centered on the parent .columns element.
+  \ While you can use empty columns (like <div class="column"></div>) to create horizontal space around .column elements,
+  \ you can also use .is-centered on the parent .columns element.
 
   ### modifiers
 
@@ -321,13 +321,13 @@ text weight:
   default: .container>.notification{Container content.}
 
   fluid:
-  | If you don't want to have a maximum width but want to keep the 32px margin on the left and right sides, add the is-fluid modifier.
+  \ If you don't want to have a maximum width but want to keep the 32px margin on the left and right sides, add the is-fluid modifier.
 
   responsive:
-  | With the two modifiers .is-widescreen and .is-fullhd, you can have a fullwidth container until those specific breakpoints.
+  \ With the two modifiers .is-widescreen and .is-fullhd, you can have a fullwidth container until those specific breakpoints.
 
   style:
-  | If you don't want to see an arrow on on the side of the navbar, add the is-arrowless modifier.
+  \ If you don't want to see an arrow on on the side of the navbar, add the is-arrowless modifier.
 
   ### modifiers
 
@@ -356,8 +356,8 @@ text weight:
   default: nav.level>.level-left>.level-item>p.subtitle.is-5>strong{123}^posts^^.level-item>.field.has-addons>p.control>input.input[placeholder={Find a post}]^p.control>button.button{Search}
 
   responsive:
-  | By default, for space concerns, the level is vertical on mobile. If you want the level to be horizontal on mobile as well,
-  | add the is-mobile modifier on the level container.
+  \ By default, for space concerns, the level is vertical on mobile. If you want the level to be horizontal on mobile as well,
+  \ add the is-mobile modifier on the level container.
 
   ### modifiers
 
@@ -387,13 +387,13 @@ text weight:
   default: section.hero.is-primary>.hero-body>.container>h1.title{Hero title}+h2.subtitle{Hero subtitle}
 
   colors:
-  | As with buttons, you can choose one of the 7 different colors.
+  \ As with buttons, you can choose one of the 7 different colors.
 
   gradients:
-  | By adding the is-bold modifier, you can generate a subtle gradient.
+  \ By adding the is-bold modifier, you can generate a subtle gradient.
 
   sizes:
-  | You can have even more imposing banners by using one of 3 different sizes.
+  \ You can have even more imposing banners by using one of 3 different sizes.
 
   ### modifiers
 
@@ -490,22 +490,22 @@ text weight:
   default: a.button{Button}
 
   colors:
-  | Colored buttons.
+  \ Colored buttons.
 
   sizes:
-  | Size matters.
+  \ Size matters.
 
   outlined:
-  | Outlined.
+  \ Outlined.
 
   inverted:
-  | Inverted.
+  \ Inverted.
 
   rounded:
-  | Rounded.
+  \ Rounded.
 
   loading:
-  | Loading
+  \ Loading
 
   ### modifiers
 
@@ -554,7 +554,7 @@ text weight:
   default: .content>ol>li{Coffee}+li{Tea}+li{Milk}
 
   sizes:
-  | You can use the is-small, is-medium and is-large modifiers to change the font size.
+  \ You can use the is-small, is-medium and is-large modifiers to change the font size.
 
   ### modifiers
 
@@ -576,7 +576,7 @@ text weight:
   default: a.delete
 
   sizes:
-  | It comes in 4 sizes.
+  \ It comes in 4 sizes.
 
   ### modifiers
 
@@ -591,10 +591,10 @@ text weight:
   default: span.icon>i.fas.fa-home
 
   colors:
-  | Since icon fonts are simply text, you can use the text color modifiers to change the icon's color.
+  \ Since icon fonts are simply text, you can use the text color modifiers to change the icon's color.
 
   sizes:
-  | Size matters.
+  \ Size matters.
 
   ### modifiers
 
@@ -611,10 +611,10 @@ text weight:
   default: figure.image>img[src=https://bulma.io/images/placeholders/128x128.png]
 
   ratio:
-  | There are 7 dimensions to choose from, useful for avatars.
+  \ There are 7 dimensions to choose from, useful for avatars.
 
   rounded:
-  | You can also make rounded images, using .is-rounded class.
+  \ You can also make rounded images, using .is-rounded class.
 
   ### modifiers
 
@@ -650,7 +650,7 @@ text weight:
   default: .notification>button.delete+{Lorem ipsum dolor sit amet.}
 
   colors:
-  | Colored notifications.
+  \ Colored notifications.
 
   ### modifiers
 
@@ -667,10 +667,10 @@ text weight:
   default: progress.progress
 
   colors:
-  | Colored progress bars.
+  \ Colored progress bars.
 
   sizes:
-  | Size matters.
+  \ Size matters.
 
   ### modifiers
 
@@ -688,19 +688,19 @@ text weight:
   default: table.table>thead>tr>th{Pos}+th{Pts}^^tfoot>tr>th{Pos}+th{Pts}^^tbody>tr>th{1}+td{Leicester City}+td{81}
 
   bordered:
-  | Add borders to all the cells.
+  \ Add borders to all the cells.
 
   striped:
-  | Add stripes to the table.
+  \ Add stripes to the table.
 
   narrow:
-  | Make the cells narrower.
+  \ Make the cells narrower.
 
   hoverable:
-  | You can add a hover effect on each row.
+  \ You can add a hover effect on each row.
 
   fullwidth:
-  | You can have a fullwidth table.
+  \ You can have a fullwidth table.
 
   ### modifiers
 
@@ -732,16 +732,16 @@ text weight:
   default: span.tag{Tag label}
 
   colors:
-  | Like with buttons, there are 10 different colors available.
+  \ Like with buttons, there are 10 different colors available.
 
   sizes:
-  | And 2 additional sizes.
+  \ And 2 additional sizes.
 
   rounded:
-  | You can add the is-rounded modifier to make a rounded tag.
+  \ You can add the is-rounded modifier to make a rounded tag.
 
   delete:
-  | You can add the is-delete modifier to turn the tag into a delete button.
+  \ You can add the is-delete modifier to turn the tag into a delete button.
 
   ### modifiers
 
@@ -793,7 +793,7 @@ text weight:
   default: h1.title{Title}
 
   spaced:
-  | You can maintain the normal spacing between titles and subtitles if you use the is-spaced modifier on the first element.
+  \ You can maintain the normal spacing between titles and subtitles if you use the is-spaced modifier on the first element.
 
   ### modifiers
 
@@ -824,13 +824,13 @@ text weight:
   default: .tabs>ul>li.is-active>a{Pictures}^li>a{Music}^li>a{Documents}
 
   alignment:
-  | To align the tabs list, use the is-centered or is-right modifier on the .tabs container.
+  \ To align the tabs list, use the is-centered or is-right modifier on the .tabs container.
 
   sizes:
-  | You can choose between 3 additional sizes ; is-small is-medium and is-large.
+  \ You can choose between 3 additional sizes ; is-small is-medium and is-large.
 
   styles:
-  | Stylised tabs.
+  \ Stylised tabs.
 
   ### modifiers
 

--- a/examples/mini-3.0.0.spec
+++ b/examples/mini-3.0.0.spec
@@ -33,9 +33,9 @@ global sizes:
   ## Button
 
   desc:
-  | Buttons and button-like input elements have been styled by default to be consistent across browsers.
-  | You can also style other elements, such as links or form labels, to look like buttons, using the appropriate class
-  | (.button)or the button role.
+  \ Buttons and button-like input elements have been styled by default to be consistent across browsers.
+  \ You can also style other elements, such as links or form labels, to look like buttons, using the appropriate class
+  \ (.button)or the button role.
 
   dom:
   - button
@@ -52,11 +52,11 @@ global sizes:
   default: button{Button}
 
   color variants:
-  | To make your buttons stand out, you can give them a primary (.primary), secondary (.secondary),
-  | tertiary (.tertiary) or inversed (.inverse) color palette.
+  \ To make your buttons stand out, you can give them a primary (.primary), secondary (.secondary),
+  \ tertiary (.tertiary) or inversed (.inverse) color palette.
 
   size variants:
-  | You can make buttons smaller (.small) or larger (.large), by applying the appropriate modifier.
+  \ You can make buttons smaller (.small) or larger (.large), by applying the appropriate modifier.
 
   ### modifiers
 
@@ -68,9 +68,9 @@ global sizes:
   ## Image
 
   desc:
-  | Image elements are responsive by default, automatically scaling down as necessary to display properly on smaller devices.
-  | Images retain their original aspect ratio and they will never scale above their original size.
-  | If you want to add captions to images, you can use HTML5 figure elements, along with their related captions.
+  \ Image elements are responsive by default, automatically scaling down as necessary to display properly on smaller devices.
+  \ Images retain their original aspect ratio and they will never scale above their original size.
+  \ If you want to add captions to images, you can use HTML5 figure elements, along with their related captions.
 
   dom: figure>img+figcaption
 
@@ -86,9 +86,9 @@ global sizes:
   ## Card
 
   desc:
-  | mini.css provides you with cards (.card), general-purpose containers that help you organize the content of your web apps.
-  | Cards should be used in combination with the grid system, meaning that they need to be placed inside a grid's rows to work
-  | properly. Layouts created with cards are responsive, realigning according to the available size on the screen.
+  \ mini.css provides you with cards (.card), general-purpose containers that help you organize the content of your web apps.
+  \ Cards should be used in combination with the grid system, meaning that they need to be placed inside a grid's rows to work
+  \ properly. Layouts created with cards are responsive, realigning according to the available size on the screen.
 
   dom: .card
 
@@ -97,14 +97,14 @@ global sizes:
   default: .card>h3{Card}+p{This is a basic card with some sample content}
 
   alternative sizes:
-  | You can create small (.small, 240px wide) or large (.large, 480px wide) cards by applying the appropriate modifiers
-  | to a card. Apart from that, you can also create fluid (.fluid) cards, that take up as much space as is available,
-  | however you will have to place these cards inside a grid layout's columns, effectively adding one extra step for them
-  | to display properly.
+  \ You can create small (.small, 240px wide) or large (.large, 480px wide) cards by applying the appropriate modifiers
+  \ to a card. Apart from that, you can also create fluid (.fluid) cards, that take up as much space as is available,
+  \ however you will have to place these cards inside a grid layout's columns, effectively adding one extra step for them
+  \ to display properly.
 
   color variants:
-  | You can display warning (.warning) or error (.error) messages using cards, simply by adding the appropriate color
-  | modifiers to a card.
+  \ You can display warning (.warning) or error (.error) messages using cards, simply by adding the appropriate color
+  \ modifiers to a card.
 
   ### modifiers
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
-const eno = require('enojs')
+const enolib = require('enolib')
+const { TerminalReporter } = require('enolib');
 const { debug, error } = require('loglevel')
 const { expandEmmet } = require('./helpers/dom')
 
@@ -10,44 +11,46 @@ function parse (specFile) {
   }
 
   const input = fs.readFileSync(specFile, 'utf-8')
-  const document = eno.parse(input, { reporter: 'terminal' })
+  const document = enolib.parse(input, { reporter: TerminalReporter })
 
   const result = {
-    name: document.field('name'),
-    title: document.field('title'),
-    version: document.field('version'),
-    language: document.field('language'),
-    author: document.field('author'),
-    stylesheet: document.field('stylesheet'),
-    homepage: document.field('homepage'),
-    description: document.field('description'),
-    docTemplate: document.field('doc template'),
+    name: document.field('name').requiredStringValue(),
+    title: document.field('title').requiredStringValue(),
+    version: document.field('version').requiredStringValue(),
+    language: document.field('language').requiredStringValue(),
+    author: document.field('author').requiredStringValue(),
+    stylesheet: document.field('stylesheet').requiredStringValue(),
+    homepage: document.field('homepage').requiredStringValue(),
+    description: document.field('description').requiredStringValue(),
+    docTemplate: document.field('doc template').optionalStringValue(),
     categories: {}
   }
 
-  const categories = document.elements().filter(e => e.instruction.type === 'SECTION')
+  const categories = document.elements()
+                             .filter(element => element.yieldsSection())
+                             .map(element => element.toSection())
 
   for (const category of categories) {
-    const categoryName = category.name
+    const categoryName = category.stringKey()
     debug(categoryName)
 
-    result.categories[category.name] = {
-      name: category.name,
+    result.categories[categoryName] = {
+      name: categoryName,
       elements: []
     }
 
-    for (const elem of category._elements) {
-      debug('-', elem.name)
+    for (const elem of category.sections()) {
+      debug('-', elem.stringKey())
       const element = {}
-      element.name = elem.name
-      element.desc = elem.field('desc')
+      element.name = elem.stringKey()
+      element.desc = elem.field('desc').optionalStringValue()
 
       // element DOM
       let dom
-      try {
-        dom = [elem.field('dom')]
-      } catch (e) {
-        dom = elem.list('dom')
+      if(elem.element('dom').yieldsField()) {
+        dom = [elem.field('dom').requiredStringValue()]
+      } else {
+        dom = elem.list('dom').requiredStringValues()
       }
       dom = dom.map(expandEmmet)
       element.dom = dom
@@ -60,12 +63,13 @@ function parse (specFile) {
           Object.assign(...Object.keys(modifiers).map(mod => ({ [mod]: modifiers[mod] })))
         element.modifiers = element.modifiers.map(mod => expandEmmet(mod).html)
       } catch (e) {
-        debug(`No modifiers found for ${elem.name}`)
+        debug(`No modifiers found for ${element.name}`)
       }
 
       // element examples
-      try {
-        const examples = Object.assign(...elem.section('examples').raw().examples)
+      if(elem.optionalSection('examples') !== null) {
+        const examples =
+          elem.section('examples').fields().reduce((obj, field) => ({ ...obj, [field.stringKey()]: field.requiredStringValue() }), {})
         const defaultExample = examples.default
         examples.default = expandEmmet(defaultExample)
         const examplesWithModifiers = Object.keys(examples).filter(name => name !== 'default')
@@ -78,14 +82,14 @@ function parse (specFile) {
           }
         })
         element.examples = examples
-      } catch (e) {
-        debug(`No examples found for ${elem.name}`)
+      } else {
+        debug(`No examples found for ${element.name}`)
       }
 
       // element parents
-      element.parents = elem.list('parents')
+      element.parents = elem.list('parents').requiredStringValues()
 
-      result.categories[category.name].elements.push(element)
+      result.categories[categoryName].elements.push(element)
     }
   }
 
@@ -93,8 +97,8 @@ function parse (specFile) {
 }
 
 function iterateElement (elem, section) {
-  const collection = elem.section(section).elements()
-  return Object.assign(...collection.map(e => ({ [e.name]: e.items() })))
+  const collection = elem.section(section).lists()
+  return collection.reduce((obj, list) => ({ ...obj, [list.stringKey()]: list.requiredStringValues() }), {})
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@emmetio/html-transform": "^0.3.10",
     "commander": "^2.19.0",
     "eminent": "^0.0.8",
-    "enojs": "^0.16.1",
+    "enolib": "^0.8.2",
     "loglevel": "^1.6.1",
     "mkdirp": "^0.5.1",
     "pug": "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,9 +356,10 @@ emmet@^1.3.1:
   dependencies:
     caniuse-db "^1.0.30000161"
 
-enojs@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/enojs/-/enojs-0.16.1.tgz#6f6087dcb1c0be449e549f6fb3b82f2342e986fc"
+enolib@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/enolib/-/enolib-0.8.2.tgz#cc214fd9e99df22de32ec9ac3ecab4b9ddc82cee"
+  integrity sha512-kfeb9gAi+VkOHGzuSpb1wMNPPJ9CfbLabkzWGcPW37CDxtpPgIKeBAQsG0qJmY3zNTd4nu05ZYahqpPay1vrzw==
 
 escodegen@^1.6.1:
   version "1.11.0"


### PR DESCRIPTION
Hi! :wave: 

Not sure if this is still active, but anyhow I took the liberty to work out a PR that ports the parser code from enojs (which is EOL as of the beginning of the year) to enolib (which is more capable and actively maintained).

Feel free to use this, not use this, throw it away ... I made it in full awareness it might be entirely futile. :)

Two more notes:
- I verified the changes by ensuring the parsing output (for the three examples in the repository) is identical before and after my changes - this of course does not prove my changes are fully correct, but it's probably a good indicator :)
- enolib supports the final (and now only specification) for eno, in which there was a small change to the continuations featureset (https://github.com/eno-lang/eno/blob/master/rfcs-final-spec/restrict-fields-to-a-single-line-rev1.md) - therefore I also adapted the examples so the lines in the description texts are now not `\n` separated anymore (this is now only possible when using multiline fields), but seperated by spaces (which for the usecase seems acceptable to me anyhow, maybe even preferable)

Thanks for using eno! :tada: 

Best,
Simon